### PR TITLE
Display 404, Google link, creatures_tag on creature show pg

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  # def not_found
-  #   raise ActionController::RoutingError.new("Not Found")
-  # end
+  def not_found
+    raise ActionController::RoutingError.new("These are not the pages you're looking for!")
+  end
 
 end
 

--- a/app/controllers/creatures_controller.rb
+++ b/app/controllers/creatures_controller.rb
@@ -89,5 +89,4 @@ class CreaturesController < ApplicationController
       redirect_to '/404.html' unless  @creature = Creature.find_by_id(params[:id])
     end
 
-
 end

--- a/app/views/creatures/show.html.erb
+++ b/app/views/creatures/show.html.erb
@@ -7,7 +7,7 @@
       <strong>Description: </strong><%= @creature.desc %></h4>
       <h4>Tags:</h4>
         <% @creature.tags.each do |tag| %>
-            <h5><%= link_to tag.name, tag_path(tag.name) %></h5>
+            <h5><%= link_to tag.name, creatures_tag_path(tag.name) %></h5>
         <% end %>
 
       <br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 <body>
   <div class="container">
     <h1>Bog Adventure App</h1>
-    <h4><%= link_to "Home", root_path %> | <%= link_to "Add Creature", new_creature_path %> | <a href="http://www.google">Google</a> | <%= link_to "Tags", tags_path %></h4>
+    <h4><%= link_to "Home", root_path %> | <%= link_to "Add Creature", new_creature_path %> | <a href="http://www.google.com">Google</a> | <%= link_to "Tags", tags_path %></h4>
 
 
   <hr>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = true   #change this to false to see 404.html
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,11 @@ Rails.application.routes.draw do
   # Example of regular route:
   resources :creatures, :tags
 
-  get 'creatures/tag/:tag' => 'tags#tag' #, as: :tag
+  get 'creatures/tag/:tag' => 'tags#tag', as: :creatures_tag
 
   # 404 error handling route
-  #get '*path', to: "application#not_found" # => redirect('/404.html')
+  #get '*path', to: "application#not_found" # => redirect('/404.html
+  get '*path', to: "application#not_found"
 
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase


### PR DESCRIPTION
RE: 404 errors on non GET urls: production is now set to display custom 404.html error while development shows development errors;
go to config>environments>development.rb and change config.consider_all_requests_local to false to show custom error messages in development

Google link in header now links to Google.com

creatures_tag prefix added to route for tags#tag.  From creatures#show you can now link back to list of all creatures that match the linked tag.  (changed: tag_path(tag.name) to creatures_tag_path(tag.name)
